### PR TITLE
ci: add lint, test, type-check, and security workflows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
+---
 name: Lint
 
-on:
+"on":
   push:
     branches: [main, develop]
   pull_request:
@@ -22,7 +23,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-lint-${{ hashFiles('**/requirements*.txt') }}
+          key: >-
+            ${{ runner.os }}-pip-lint-${{
+            hashFiles('**/requirements*.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-lint-
             ${{ runner.os }}-pip-

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,7 @@
+---
 name: Security Scan
 
-on:
+"on":
   push:
     branches: [main, develop]
   pull_request:
@@ -25,7 +26,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-security-${{ hashFiles('**/requirements*.txt') }}
+          key: >-
+            ${{ runner.os }}-pip-security-${{
+            hashFiles('**/requirements*.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-security-
             ${{ runner.os }}-pip-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
+---
 name: Test
 
-on:
+"on":
   push:
     branches: [main, develop]
   pull_request:
@@ -22,7 +23,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-test-${{ hashFiles('**/requirements*.txt') }}
+          key: >-
+            ${{ runner.os }}-pip-test-${{
+            hashFiles('**/requirements*.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-test-
             ${{ runner.os }}-pip-
@@ -33,7 +36,8 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest --cov=src --cov-report=xml --cov-report=term --cov-fail-under=70
+          pytest --cov=src --cov-report=xml \
+            --cov-report=term --cov-fail-under=70
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,6 +1,7 @@
+---
 name: Type Check
 
-on:
+"on":
   push:
     branches: [main, develop]
   pull_request:
@@ -22,7 +23,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-mypy-${{ hashFiles('**/requirements*.txt') }}
+          key: >-
+            ${{ runner.os }}-pip-mypy-${{
+            hashFiles('**/requirements*.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-mypy-
             ${{ runner.os }}-pip-


### PR DESCRIPTION
## Summary
- Copied 4 CI workflow templates from `beat-books-infra/ci-templates/` to `.github/workflows/`
- **lint.yml**: ruff + black checks on `src/`
- **test.yml**: pytest with `--cov-fail-under=70` coverage threshold + Codecov upload
- **type-check.yml**: mypy with `--ignore-missing-imports`
- **security.yml**: bandit code scan + pip-audit dependency check (also runs weekly on Monday 9AM UTC)
- All workflows trigger on push/PR to `main` and `develop`

## Test plan
- [ ] Verify workflows appear in GitHub Actions tab
- [ ] Create a test PR to confirm lint, test, type-check, and security jobs run
- [ ] Confirm `--cov-fail-under=70` is present in test.yml

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)