### PR TITLE
fix: remove hardcoded database credentials, use config.py settings

### DIFF
--- a/src/core/database.py
+++ b/src/core/database.py
@@ -1,8 +1,7 @@
 # core/database.py
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from src.core.config import settings
 
-DATABASE_URL = "postgresql://neondb_owner:npg_9bsVixcUeu3E@ep-purple-glade-adlsv7d9-pooler.c-2.us-east-1.aws.neon.tech/neondb?sslmode=require"
-
-engine = create_engine(DATABASE_URL)
+engine = create_engine(settings.DATABASE_URL)
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)


### PR DESCRIPTION
## Summary

Fixed critical security vulnerability in `src/core/database.py` that had hardcoded database credentials with exposed password.

## Changes

- Removed hardcoded DATABASE_URL from `database.py`
- Import and use `settings.DATABASE_URL` from `config.py` instead
- Database URL now properly reads from environment variables
- Maintains backward compatibility with all existing imports

## Related Issues

Closes #24
Addresses requirements from PR #23

## Security

✅ Removes exposed credentials from source code
✅ Follows CLAUDE.md guidelines: "Never hardcode database URLs"
✅ Uses centralized configuration pattern

---
Generated with [Claude Code](https://claude.ai/code)