### PR TITLE
fix: repair broken test fixtures and mock targets

### DIFF
--- a/tests/test_unit/test_repositories/conftest.py
+++ b/tests/test_unit/test_repositories/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+from src.entities.team_offense import TeamOffense
+
+
+@pytest.fixture
+def sample_team_offense():
+    """A TeamOffense entity with representative data for unit tests."""
+    return TeamOffense(
+        season=2023, rk=1, tm="KAN", g=17, pf=450,
+    )

--- a/tests/test_unit/test_services/test_team_offense_service.py
+++ b/tests/test_unit/test_services/test_team_offense_service.py
@@ -133,9 +133,9 @@ class TestScrapeAndStoreTeamOffense:
     """Tests for scrape_and_store_team_offense end-to-end with mocks."""
 
     @pytest.mark.asyncio
-    @patch("src.services.team_offense_service.SessionLocal")
+    @patch("src.core.database.SessionLocal")
     @patch("src.services.team_offense_service.get_dataframe")
-    def test_calls_repo_create_for_each_record(self, mock_get_df, mock_session_local):
+    async def test_calls_repo_create_for_each_record(self, mock_get_df, mock_session_local):
         """Should call repo.create for each parsed record."""
         mock_get_df.return_value = [
             {
@@ -203,38 +203,34 @@ class TestScrapeAndStoreTeamOffense:
         mock_session = MagicMock()
         mock_session_local.return_value = mock_session
 
-        result = asyncio.get_event_loop().run_until_complete(
-            scrape_and_store_team_offense(2023)
-        )
+        result = await scrape_and_store_team_offense(2023)
 
         assert mock_session.commit.called
         assert len(result) == 2
 
     @pytest.mark.asyncio
-    @patch("src.services.team_offense_service.SessionLocal")
+    @patch("src.core.database.SessionLocal")
     @patch("src.services.team_offense_service.get_dataframe")
-    def test_session_closed_on_success(self, mock_get_df, mock_session_local):
+    async def test_session_closed_on_success(self, mock_get_df, mock_session_local):
         """Session should be closed after successful scrape."""
         mock_get_df.return_value = []
         mock_session = MagicMock()
         mock_session_local.return_value = mock_session
 
-        asyncio.get_event_loop().run_until_complete(scrape_and_store_team_offense(2023))
+        await scrape_and_store_team_offense(2023)
 
         assert mock_session.close.called
 
     @pytest.mark.asyncio
-    @patch("src.services.team_offense_service.SessionLocal")
+    @patch("src.core.database.SessionLocal")
     @patch("src.services.team_offense_service.get_dataframe")
-    def test_session_closed_on_failure(self, mock_get_df, mock_session_local):
+    async def test_session_closed_on_failure(self, mock_get_df, mock_session_local):
         """Session should be closed even when scraping fails."""
         mock_get_df.side_effect = Exception("Network error")
         mock_session = MagicMock()
         mock_session_local.return_value = mock_session
 
         with pytest.raises(Exception, match="Network error"):
-            asyncio.get_event_loop().run_until_complete(
-                scrape_and_store_team_offense(2023)
-            )
+            await scrape_and_store_team_offense(2023)
 
         assert mock_session.close.called


### PR DESCRIPTION
## What changed

- Added missing `sample_team_offense` fixture (`tests/test_unit/test_repositories/conftest.py`)
- Fixed mock targets in `test_team_offense_service.py`: patched `src.core.database.SessionLocal` instead of non-existent `src.services.team_offense_service.SessionLocal`
- Converted sync test functions to `async def` to match their `@pytest.mark.asyncio` decorators

## How to test

```bash
uv run pytest tests/test_unit/ -v
# All 221 tests pass (was 194 passed + 4 errors before this fix)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)