### PR TITLE
feat: Scrapling as default scrape backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,16 +34,25 @@ ODDS_API_KEY=
 ODDS_API_BASE_URL=https://api.the-odds-api.com
 
 # -----------------------------------------------------------------------------
-# Scraping — Rate Limiting & Timing
+# Scraping — Backend & Rate Limiting
 # -----------------------------------------------------------------------------
+# Backend: "scrapling" (default, no Chrome needed) or "selenium" (requires Chrome)
+SCRAPE_BACKEND=scrapling
 SCRAPE_DELAY_SECONDS=60
 SCRAPE_REQUEST_TIMEOUT=30
 SCRAPE_MAX_RETRIES=3
-# Browser interaction timing (seconds)
+# Browser interaction timing (seconds, used by Selenium backend)
 SCRAPE_PAGE_LOAD_WAIT=1.0
 SCRAPE_CLICK_DELAY=0.4
 SCRAPE_CLOUDFLARE_INITIAL_WAIT=10.0
 SCRAPE_CLOUDFLARE_EXTENDED_WAIT=15.0
+
+# -----------------------------------------------------------------------------
+# Scrapling Settings (only used when SCRAPE_BACKEND=scrapling)
+# -----------------------------------------------------------------------------
+SCRAPLING_FETCHER_TYPE=stealthy
+SCRAPLING_TIMEOUT=30
+SCRAPLING_IMPERSONATE=chrome
 
 # -----------------------------------------------------------------------------
 # Application Settings (Optional — have sensible defaults)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "selenium-stealth",
     "webdriver-manager",
     "openpyxl",
+    "scrapling",
 ]
 
 [project.optional-dependencies]

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -44,6 +44,14 @@ class Settings(BaseSettings):
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36",  # noqa: E501
     ]
 
+    # Scraping — backend selection
+    SCRAPE_BACKEND: Literal["selenium", "scrapling"] = "scrapling"
+
+    # Scrapling-specific settings
+    SCRAPLING_FETCHER_TYPE: Literal["fetcher", "stealthy"] = "stealthy"
+    SCRAPLING_TIMEOUT: int = 30
+    SCRAPLING_IMPERSONATE: str = "chrome"
+
     # Proxy rotation (optional)
     SCRAPE_USE_PROXY: bool = False
     SCRAPE_PROXY_LIST: list[

--- a/src/services/defense_stats_service.py
+++ b/src/services/defense_stats_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -48,7 +48,7 @@ COLUMN_MAP = {
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
     table = find_pfr_table(page_source, PFR_TABLE_ID)
 
     if table is None:

--- a/src/services/games_service.py
+++ b/src/services/games_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -34,7 +34,7 @@ COLUMN_MAP = {
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
     table = find_pfr_table(page_source, PFR_TABLE_ID)
 
     if table is None:

--- a/src/services/kicking_stats_service.py
+++ b/src/services/kicking_stats_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -53,7 +53,7 @@ COLUMN_MAP = {
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
     table = find_pfr_table(page_source, PFR_TABLE_ID)
 
     if table is None:

--- a/src/services/kicking_team_service.py
+++ b/src/services/kicking_team_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -49,7 +49,7 @@ COLUMN_MAP = {
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
     table = find_pfr_table(page_source, PFR_TABLE_ID)
 
     if table is None:

--- a/src/services/passing_stats_service.py
+++ b/src/services/passing_stats_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -56,7 +56,7 @@ COLUMN_MAP = {
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
     table = find_pfr_table(page_source, PFR_TABLE_ID)
 
     if table is None:

--- a/src/services/punting_stats_service.py
+++ b/src/services/punting_stats_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -44,7 +44,7 @@ COLUMN_MAP = {
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
     table = find_pfr_table(page_source, PFR_TABLE_ID)
 
     if table is None:

--- a/src/services/punting_team_service.py
+++ b/src/services/punting_team_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -39,7 +39,7 @@ COLUMN_MAP = {
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
     table = find_pfr_table(page_source, PFR_TABLE_ID)
 
     if table is None:

--- a/src/services/receiving_stats_service.py
+++ b/src/services/receiving_stats_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -44,7 +44,7 @@ COLUMN_MAP = {
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
     table = find_pfr_table(page_source, PFR_TABLE_ID)
 
     if table is None:

--- a/src/services/return_stats_service.py
+++ b/src/services/return_stats_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -43,7 +43,7 @@ COLUMN_MAP = {
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
     table = find_pfr_table(page_source, PFR_TABLE_ID)
 
     if table is None:

--- a/src/services/returns_team_service.py
+++ b/src/services/returns_team_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -38,7 +38,7 @@ COLUMN_MAP = {
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
     table = find_pfr_table(page_source, PFR_TABLE_ID)
 
     if table is None:

--- a/src/services/rushing_stats_service.py
+++ b/src/services/rushing_stats_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -42,7 +42,7 @@ COLUMN_MAP = {
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
     table = find_pfr_table(page_source, PFR_TABLE_ID)
 
     if table is None:

--- a/src/services/scoring_stats_service.py
+++ b/src/services/scoring_stats_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -49,7 +49,7 @@ COLUMN_MAP = {
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
     table = find_pfr_table(page_source, PFR_TABLE_ID)
 
     if table is None:

--- a/src/services/standings_service.py
+++ b/src/services/standings_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -68,7 +68,7 @@ def _parse_table(table: Tag, season: int) -> list[dict]:
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
 
     all_rows = []
     for table_id in PFR_TABLE_IDS:

--- a/src/services/team_defense_service.py
+++ b/src/services/team_defense_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -52,7 +52,7 @@ COLUMN_MAP = {
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
     table = find_pfr_table(page_source, PFR_TABLE_ID)
 
     if table is None:

--- a/src/services/team_offense_service.py
+++ b/src/services/team_offense_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.core.scraper_utils import (
     clean_value,
-    fetch_page_with_selenium,
+    fetch_page,
     find_pfr_table,
     retry_with_backoff,
 )
@@ -52,7 +52,7 @@ COLUMN_MAP = {
 
 def get_dataframe(season: int) -> list[dict]:
     url = PFR_URL_TEMPLATE.format(season=season)
-    page_source = retry_with_backoff(fetch_page_with_selenium, url, url=url)
+    page_source = retry_with_backoff(fetch_page, url, url=url)
     table = find_pfr_table(page_source, PFR_TABLE_ID)
 
     if table is None:

--- a/tests/test_scraper_utils.py
+++ b/tests/test_scraper_utils.py
@@ -242,6 +242,44 @@ class TestRetryWithBackoff:
         assert mock_func.call_count == 2
 
 
+class TestFetchPageDispatch:
+    """Tests for fetch_page backend dispatch."""
+
+    def test_fetch_page_dispatches_to_scrapling(self):
+        """When SCRAPE_BACKEND=scrapling, fetch_page calls scrapling fetcher."""
+        with patch.object(settings, "SCRAPE_BACKEND", "scrapling"):
+            with patch(
+                "src.core.scrapling_fetcher.fetch_page_with_scrapling",
+                return_value="<html>scrapling</html>",
+            ) as mock_scrapling:
+                from src.core.scraper_utils import fetch_page
+
+                result = fetch_page("http://example.com")
+                mock_scrapling.assert_called_once_with("http://example.com")
+                assert result == "<html>scrapling</html>"
+
+    def test_fetch_page_dispatches_to_selenium(self):
+        """When SCRAPE_BACKEND=selenium, fetch_page calls selenium fetcher."""
+        with patch.object(settings, "SCRAPE_BACKEND", "selenium"):
+            with patch(
+                "src.core.scraper_utils.fetch_page_with_selenium",
+                return_value="<html>selenium</html>",
+            ) as mock_selenium:
+                from src.core.scraper_utils import fetch_page
+
+                result = fetch_page("http://example.com")
+                mock_selenium.assert_called_once_with("http://example.com")
+                assert result == "<html>selenium</html>"
+
+    def test_fetch_page_raises_on_unknown_backend(self):
+        """When SCRAPE_BACKEND is invalid, fetch_page raises ValueError."""
+        with patch.object(settings, "SCRAPE_BACKEND", "unknown"):
+            from src.core.scraper_utils import fetch_page
+
+            with pytest.raises(ValueError, match="Unknown SCRAPE_BACKEND"):
+                fetch_page("http://example.com")
+
+
 class TestConfigurationSettings:
     """Tests for scraping configuration settings."""
 


### PR DESCRIPTION
## Summary
- Makes Scrapling the default scrape backend (`SCRAPE_BACKEND=scrapling`), eliminating the need for Chrome/Selenium in Docker for season-stat scrapes
- Adds `SCRAPE_BACKEND`, `SCRAPLING_FETCHER_TYPE`, `SCRAPLING_TIMEOUT`, `SCRAPLING_IMPERSONATE` config fields
- Refactors all 15 season-stat services to use the unified `fetch_page()` dispatcher instead of `fetch_page_with_selenium()` directly
- `scrape_service.py` (team gamelog Excel export) retains Selenium since it needs browser interaction

## Changes
- `src/core/config.py`: New Scrapling config fields with defaults
- `pyproject.toml`: Add `scrapling` dependency
- `src/services/*.py`: 15 files switched from `fetch_page_with_selenium` → `fetch_page`
- `tests/test_scraper_utils.py`: Tests for backend dispatch logic
- `.env.example`: Document new config vars

## Test plan
- [ ] `pytest tests/test_scraper_utils.py -v` passes
- [ ] `SCRAPE_BACKEND=scrapling` dispatches to scrapling fetcher
- [ ] `SCRAPE_BACKEND=selenium` dispatches to selenium fetcher
- [ ] Invalid backend raises ValueError