### PR TITLE
fix: /api/v1/games returns 200 + regression test

### DIFF
--- a/src/repositories/games_repo.py
+++ b/src/repositories/games_repo.py
@@ -14,6 +14,7 @@ class GamesRepository(BaseRepository[Games]):
     def find_by_season(
         self,
         season: int,
+        week: int | None = None,
         *,
         limit: int = 300,
         offset: int = 0,
@@ -22,6 +23,9 @@ class GamesRepository(BaseRepository[Games]):
     ) -> list[Games]:
         """Find all games for a given season with pagination and sorting."""
         stmt = select(self.model).where(self.model.season == season)
+
+        if week is not None:
+            stmt = stmt.where(self.model.week == week)
 
         sort_column = getattr(self.model, sort_by, None)
         if sort_column is not None:
@@ -33,7 +37,7 @@ class GamesRepository(BaseRepository[Games]):
         stmt = stmt.limit(limit).offset(offset)
         return list(self.session.execute(stmt).scalars().all())
 
-    def count_by_season(self, season: int) -> int:
+    def count_by_season(self, season: int, week: int | None = None) -> int:
         """Count total games for a season."""
         from sqlalchemy import func
 
@@ -42,4 +46,6 @@ class GamesRepository(BaseRepository[Games]):
             .select_from(self.model)
             .where(self.model.season == season)
         )
+        if week is not None:
+            stmt = stmt.where(self.model.week == week)
         return self.session.execute(stmt).scalar() or 0

--- a/src/services/stats_retrieval_service.py
+++ b/src/services/stats_retrieval_service.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
+from src.repositories.games_repo import GamesRepository
 from src.repositories.passing_stats_repo import PassingStatsRepository
 from src.repositories.receiving_stats_repo import ReceivingStatsRepository
 from src.repositories.rushing_stats_repo import RushingStatsRepository
 from src.repositories.standings_repo import StandingsRepository
-from src.repositories.team_game_repo import TeamGameRepository
 from src.repositories.team_offense_repo import TeamOffenseRepository
 
 
@@ -22,7 +22,7 @@ class StatsRetrievalService:
         self.rushing_stats_repo = RushingStatsRepository(session)
         self.receiving_stats_repo = ReceivingStatsRepository(session)
         self.standings_repo = StandingsRepository(session)
-        self.team_game_repo = TeamGameRepository(session)
+        self.games_repo = GamesRepository(session)
 
     def get_all_teams(
         self,
@@ -196,7 +196,7 @@ class StatsRetrievalService:
         # Enforce max limit
         limit = min(limit, 200)
 
-        games = self.team_game_repo.find_by_season_and_week(
+        games = self.games_repo.find_by_season(
             season=season,
             week=week,
             limit=limit,
@@ -205,7 +205,7 @@ class StatsRetrievalService:
             order=order,
         )
 
-        total = self.team_game_repo.count_by_season(season, week)
+        total = self.games_repo.count_by_season(season, week)
 
         return {
             "data": games,

--- a/tests/test_games_endpoint.py
+++ b/tests/test_games_endpoint.py
@@ -1,0 +1,129 @@
+"""Regression tests for GET /api/v1/games/{season} endpoint."""
+
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from src.core.database import get_db
+from src.entities.base import Base
+from src.entities.games import Games
+from src.main import app
+
+
+@pytest.fixture()
+def db_session():
+    """Create a test database session with games table."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+@pytest.fixture()
+def client(db_session):
+    """Create a test client with DB session override."""
+
+    def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def seed_games(db_session):
+    """Seed test games data."""
+    games = [
+        Games(
+            season=2024,
+            week=1,
+            game_day="Sun",
+            game_date=date(2024, 9, 8),
+            winner="Kansas City Chiefs",
+            loser="Baltimore Ravens",
+            pts_w=27,
+            pts_l=20,
+        ),
+        Games(
+            season=2024,
+            week=1,
+            game_day="Sun",
+            game_date=date(2024, 9, 8),
+            winner="Philadelphia Eagles",
+            loser="Green Bay Packers",
+            pts_w=34,
+            pts_l=29,
+        ),
+        Games(
+            season=2024,
+            week=2,
+            game_day="Sun",
+            game_date=date(2024, 9, 15),
+            winner="Buffalo Bills",
+            loser="Miami Dolphins",
+            pts_w=31,
+            pts_l=10,
+        ),
+    ]
+    db_session.add_all(games)
+    db_session.commit()
+    return games
+
+
+class TestGamesEndpoint:
+    """Tests for /api/v1/games/{season}."""
+
+    def test_games_returns_200(self, client, seed_games):
+        """GET /api/v1/games/2024 returns 200 with data."""
+        resp = client.get("/api/v1/games/2024")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 3
+        assert len(body["data"]) == 3
+
+    def test_games_empty_season(self, client, seed_games):
+        """GET /api/v1/games/1999 returns 200 with empty data."""
+        resp = client.get("/api/v1/games/1999")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 0
+        assert body["data"] == []
+
+    def test_games_week_filter(self, client, seed_games):
+        """GET /api/v1/games/2024?week=1 filters by week."""
+        resp = client.get("/api/v1/games/2024?week=1")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 2
+        assert body["week"] == 1
+
+    def test_games_pagination(self, client, seed_games):
+        """GET /api/v1/games/2024?limit=1&offset=1 paginates."""
+        resp = client.get("/api/v1/games/2024?limit=1&offset=1")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["data"]) == 1
+        assert body["total"] == 3
+        assert body["offset"] == 1
+        assert body["limit"] == 1
+
+    def test_games_sort_order(self, client, seed_games):
+        """GET /api/v1/games/2024?sort_by=week&order=desc returns desc."""
+        resp = client.get("/api/v1/games/2024?sort_by=week&order=desc")
+        assert resp.status_code == 200
+        body = resp.json()
+        weeks = [g["week"] for g in body["data"]]
+        assert weeks[0] >= weeks[-1]


### PR DESCRIPTION
## Summary
- Fixed `GET /api/v1/games/{season}` returning 500 error
- Root cause: `StatsRetrievalService.get_games()` used `TeamGameRepository` (queries `team_games` table) instead of `GamesRepository` (queries `games` table where data actually lives)
- Added week filtering to `GamesRepository.find_by_season()` and `count_by_season()`

## Test plan
- [x] 5 regression tests pass: 200 response, empty season, week filter, pagination, sort order
- [ ] Manual: `curl http://localhost:8001/api/v1/games/2024` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)