### PR TITLE
fix: repair alembic env + ensure upgrade head works

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -34,12 +34,10 @@ from src.entities.returns import TeamReturns
 from src.entities.games import Games
 from src.entities.standings import Standings
 from src.entities.team_game import TeamGame
-<<<<<<< claude/issue-8-20260216-0000
 from src.entities.injury_report import InjuryReport
 from src.entities.game_weather import GameWeather
-=======
 from src.entities.odds import Odds
->>>>>>> main
+from src.entities.scrape_job import ScrapeJob
 
 logger = logging.getLogger("alembic.env")
 

--- a/migrations/versions/002_create_odds_table.py
+++ b/migrations/versions/002_create_odds_table.py
@@ -28,7 +28,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '002'
-down_revision = '001'
+down_revision = '002_performance_indexes'
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/003_create_injury_reports_table.py
+++ b/migrations/versions/003_create_injury_reports_table.py
@@ -1,7 +1,7 @@
 """create injury_reports table
 
 Revision ID: 003
-Revises: 001
+Revises: 002
 Create Date: 2026-02-16 00:00:00.000000
 
 Adds the injury_reports table to track weekly NFL injury designations
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "003"
-down_revision: Union[str, None] = "001"
+down_revision: Union[str, None] = "002"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/migrations/versions/005_create_scrape_jobs.py
+++ b/migrations/versions/005_create_scrape_jobs.py
@@ -17,10 +17,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-# down_revision is None for now; will be chained to the correct
-# predecessor during rebase when other migration PRs are merged.
 revision = '005'
-down_revision = None
+down_revision = '004'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- Removed merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) from `migrations/env.py`
- Added missing entity imports: `InjuryReport`, `GameWeather`, `Odds`, `ScrapeJob`
- Fixed broken revision chain in 3 migration files:
  - `002_create_odds_table.py`: down_revision `001` → `002_performance_indexes`
  - `003_create_injury_reports_table.py`: down_revision `001` → `002`
  - `005_create_scrape_jobs.py`: down_revision `None` → `004`

## Verified
```
$ alembic history
004 -> 005 (head), create scrape_jobs table
003 -> 004, create game_weather table
002 -> 003, create injury_reports table
002_performance_indexes -> 002, create odds table
001_initial_schema -> 002_performance_indexes, add performance indexes
<base> -> 001_initial_schema, initial schema from Tables.sql

$ alembic upgrade head  # ✅ all 6 migrations applied
$ alembic current       # 005 (head)
```

## Test plan
- [x] `alembic upgrade head` on fresh SQLite — all 6 migrations apply
- [ ] `alembic upgrade head` on Neon.tech dev DB — verify production chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)